### PR TITLE
VCXProj Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ Builds
 *.svn
 *.opensdf
 *.sdf
-*.vcxproj
 *.vcxproj.filters

--- a/Snake/Snake.csproj
+++ b/Snake/Snake.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C26A3309-7A61-40B6-9998-69B78CF226C1}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Snake</RootNamespace>
     <AssemblyName>Snake</AssemblyName>
@@ -51,6 +51,9 @@
     <WarningLevel>4</WarningLevel>
     <FileAlignment>512</FileAlignment>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/dna/dna.vcxproj
+++ b/dna/dna.vcxproj
@@ -71,7 +71,7 @@
       <Profile>true</Profile>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -99,7 +99,7 @@
       <Profile>true</Profile>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/dna/dna.vcxproj
+++ b/dna/dna.vcxproj
@@ -1,0 +1,199 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{888AAA01-F58E-4E41-8BBB-78294D9DABF7}</ProjectGuid>
+    <RootNamespace>dna</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>11.0.60315.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+      <Profile>true</Profile>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <OmitFramePointers>true</OmitFramePointers>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+      <Profile>true</Profile>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="CLIFile.c" />
+    <ClCompile Include="Delegate.c" />
+    <ClCompile Include="dna.c" />
+    <ClCompile Include="Finalizer.c" />
+    <ClCompile Include="Generics.c" />
+    <ClCompile Include="Heap.c" />
+    <ClCompile Include="InternalCall.c" />
+    <ClCompile Include="JIT.c" />
+    <ClCompile Include="JIT_Execute.c" />
+    <ClCompile Include="MetaData.c" />
+    <ClCompile Include="MetaData_Fill.c" />
+    <ClCompile Include="MetaData_Search.c" />
+    <ClCompile Include="MethodState.c" />
+    <ClCompile Include="PInvoke.c" />
+    <ClCompile Include="RVA.c" />
+    <ClCompile Include="Sys.c" />
+    <ClCompile Include="Thread.c" />
+    <ClCompile Include="Type.c" />
+    <ClCompile Include="System.Array.c" />
+    <ClCompile Include="System.Char.c" />
+    <ClCompile Include="System.Console.c" />
+    <ClCompile Include="System.DateTime.c" />
+    <ClCompile Include="System.Diagnostics.Debugger.c" />
+    <ClCompile Include="System.Enum.c" />
+    <ClCompile Include="System.Environment.c" />
+    <ClCompile Include="System.GC.c" />
+    <ClCompile Include="System.IO.FileInternal.c" />
+    <ClCompile Include="System.Math.c" />
+    <ClCompile Include="System.Net.Dns.c" />
+    <ClCompile Include="System.Net.Sockets.Socket.c" />
+    <ClCompile Include="System.Object.c" />
+    <ClCompile Include="System.Runtime.CompilerServices.RuntimeHelpers.c" />
+    <ClCompile Include="System.RuntimeType.c" />
+    <ClCompile Include="System.String.c" />
+    <ClCompile Include="System.Threading.Interlocked.c" />
+    <ClCompile Include="System.Threading.Monitor.c" />
+    <ClCompile Include="System.Threading.Thread.c" />
+    <ClCompile Include="System.Type.c" />
+    <ClCompile Include="System.ValueType.c" />
+    <ClCompile Include="System.WeakReference.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CIL_OpCodes.h" />
+    <ClInclude Include="CLIFile.h" />
+    <ClInclude Include="Compat.h" />
+    <ClInclude Include="Config.h" />
+    <ClInclude Include="Delegate.h" />
+    <ClInclude Include="EvalStack.h" />
+    <ClInclude Include="Finalizer.h" />
+    <ClInclude Include="Generics.h" />
+    <ClInclude Include="Heap.h" />
+    <ClInclude Include="InternalCall.h" />
+    <ClInclude Include="JIT.h" />
+    <ClInclude Include="JIT_OpCodes.h" />
+    <ClInclude Include="MetaData.h" />
+    <ClInclude Include="MetaDataTables.h" />
+    <ClInclude Include="MethodState.h" />
+    <ClInclude Include="PInvoke.h" />
+    <ClInclude Include="PInvoke_CaseCode.h" />
+    <ClInclude Include="PInvoke_TypeDef.h" />
+    <ClInclude Include="RVA.h" />
+    <ClInclude Include="Sys.h" />
+    <ClInclude Include="Thread.h" />
+    <ClInclude Include="Type.h" />
+    <ClInclude Include="Types.h" />
+    <ClInclude Include="System.Array.h" />
+    <ClInclude Include="System.Char.CaseConversion.h" />
+    <ClInclude Include="System.Char.h" />
+    <ClInclude Include="System.Char.UC_IndexRuns.h" />
+    <ClInclude Include="System.Console.h" />
+    <ClInclude Include="System.DateTime.h" />
+    <ClInclude Include="System.Diagnostics.Debugger.h" />
+    <ClInclude Include="System.Enum.h" />
+    <ClInclude Include="System.Environment.h" />
+    <ClInclude Include="System.GC.h" />
+    <ClInclude Include="System.IO.FileInternal.h" />
+    <ClInclude Include="System.Math.h" />
+    <ClInclude Include="System.Net.Dns.h" />
+    <ClInclude Include="System.Net.Sockets.Socket.h" />
+    <ClInclude Include="System.Object.h" />
+    <ClInclude Include="System.Runtime.CompilerServices.RuntimeHelpers.h" />
+    <ClInclude Include="System.RuntimeType.h" />
+    <ClInclude Include="System.String.h" />
+    <ClInclude Include="System.Threading.Interlocked.h" />
+    <ClInclude Include="System.Threading.Monitor.h" />
+    <ClInclude Include="System.Threading.Thread.h" />
+    <ClInclude Include="System.Type.h" />
+    <ClInclude Include="System.ValueType.h" />
+    <ClInclude Include="System.WeakReference.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/libIGraph/libIGraph.vcxproj
+++ b/libIGraph/libIGraph.vcxproj
@@ -73,9 +73,9 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"
-xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\"
-xcopy "$(ProjectDir)Fonts\*.ttf" "$(SolutionDir)Builds\$(Configuration)\Fonts\"</Command>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\" /Y
+xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\" /Y
+xcopy "$(ProjectDir)Fonts\*.ttf" "$(SolutionDir)Builds\$(Configuration)\Fonts\" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -99,8 +99,9 @@ xcopy "$(ProjectDir)Fonts\*.ttf" "$(SolutionDir)Builds\$(Configuration)\Fonts\"<
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"
-xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\" /Y
+xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\" /Y
+xcopy "$(ProjectDir)Fonts\*.ttf" "$(SolutionDir)Builds\$(Configuration)\Fonts\" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/libIGraph/libIGraph.vcxproj
+++ b/libIGraph/libIGraph.vcxproj
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E8C90D0B-0F97-485C-8765-FC14202EF252}</ProjectGuid>
+    <RootNamespace>libIGraph</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>11.0.60315.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>include;include/freetype2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBIGRAPH_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>libIGraph.def</ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"
+xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\"
+xcopy "$(ProjectDir)Fonts\*.ttf" "$(SolutionDir)Builds\$(Configuration)\Fonts\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>include;include/freetype2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBIGRAPH_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>libIGraph.def</ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)Builds\$(Configuration)\"
+xcopy "$(ProjectDir)freetype.dll" "$(SolutionDir)Builds\$(Configuration)\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Bitmap.c" />
+    <ClCompile Include="BitmapLoader.c" />
+    <ClCompile Include="Brush.c" />
+    <ClCompile Include="DrawEllipses.c" />
+    <ClCompile Include="DrawLines.c" />
+    <ClCompile Include="DrawRectangles.c" />
+    <ClCompile Include="Exports.c" />
+    <ClCompile Include="Font.c" />
+    <ClCompile Include="FontFamily.c" />
+    <ClCompile Include="GetScreen.c" />
+    <ClCompile Include="Graphics.c" />
+    <ClCompile Include="Image.c" />
+    <ClCompile Include="libIGraph.c" />
+    <ClCompile Include="Pen.c" />
+    <ClCompile Include="Pixels.c" />
+    <ClCompile Include="Region.c" />
+    <ClCompile Include="StringFormat.c" />
+    <ClCompile Include="Text.c" />
+    <ClCompile Include="jidctflt.c" />
+    <ClCompile Include="tinyjpeg.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="libIGraph.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Bitmap.h" />
+    <ClInclude Include="Brush.h" />
+    <ClInclude Include="Config.h" />
+    <ClInclude Include="DrawEllipses.h" />
+    <ClInclude Include="DrawLines.h" />
+    <ClInclude Include="DrawRectangles.h" />
+    <ClInclude Include="Font.h" />
+    <ClInclude Include="FontFamily.h" />
+    <ClInclude Include="GetScreen.h" />
+    <ClInclude Include="Graphics.h" />
+    <ClInclude Include="HatchBrushDefs.h" />
+    <ClInclude Include="Image.h" />
+    <ClInclude Include="libIGraph.h" />
+    <ClInclude Include="Pen.h" />
+    <ClInclude Include="Pixels.h" />
+    <ClInclude Include="Region.h" />
+    <ClInclude Include="StringFormat.h" />
+    <ClInclude Include="Text.h" />
+    <ClInclude Include="tinyjpeg-internal.h" />
+    <ClInclude Include="tinyjpeg.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
The dna.sln was pointing at VCXPROJ files that did not exist in the project.  This adds the VCXPROJ files as well as fixes some issues with the post build steps it had previously.  With this I was able to properly build and run DNA.exe and Snake.exe.
